### PR TITLE
default namespace is different from the namespace of the traits and v…

### DIFF
--- a/yam-trait-ontology.obo
+++ b/yam-trait-ontology.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
 auto-generated-by: java
-default-namespace: YamTrait
+default-namespace: yam_trait_ontology
 
 [Term]
 id: CO_343:0000000


### PR DESCRIPTION
…ariables

Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
obo-edit and protege remove the 'namespace' line from terms that have the same namespace as the default-namespace header . This messes up the Chado loader sometimes 

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in yambase
    - [ ] checked CropOntology
