### PR TITLE
fixed mapping to an obsolete class

### DIFF
--- a/yam-trait-ontology_withcropname.obo
+++ b/yam-trait-ontology_withcropname.obo
@@ -129,7 +129,7 @@ id: CO_343:0000060
 name: yam plant vigor trait
 def: "The vigour of the vine and leaves of the new plant." [CO:curators]
 synonym: "PVigor" EXACT []
-is_a: TO:0000133
+is_a: TO:0000250
 
 [Term]
 id: CO_343:0000063


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
changed the mapping from stature or vigor trait to vigor trait

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in yambase
    - [ ] checked CropOntology
